### PR TITLE
removed a gratuitous for loop

### DIFF
--- a/scorebot/scorebot.py
+++ b/scorebot/scorebot.py
@@ -691,8 +691,6 @@ class Scheduler:
         self.status['script_err']=None
         self.status['last_error']=None
 
-        for l in self.locks:
-            del l
         self.locks = []
 
         for p in self.process_list:


### PR DESCRIPTION
 iter() does not mutate a list and self.locks is a list of multiprocessing.synchronize.Event objects.
